### PR TITLE
Add C++ and Python benchmark for FC model

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,59 @@
+import subprocess
+import time
+import numpy as np
+import torch
+from fc_model import SimpleFCModel
+
+ITERATIONS = 10000
+
+
+def save_data():
+    torch.manual_seed(0)
+    model = SimpleFCModel(10, 20, 1)
+    inp = torch.randn(1, 10)
+    np.savetxt("fc1_weight.txt", model.fc1.weight.detach().numpy().reshape(-1))
+    np.savetxt("fc1_bias.txt", model.fc1.bias.detach().numpy())
+    np.savetxt("fc2_weight.txt", model.fc2.weight.detach().numpy().reshape(-1))
+    np.savetxt("fc2_bias.txt", model.fc2.bias.detach().numpy())
+    np.savetxt("input.txt", inp.numpy().reshape(-1))
+    return model, inp
+
+
+def benchmark_python(model, inp):
+    start = time.time()
+    with torch.no_grad():
+        for _ in range(ITERATIONS):
+            model(inp)
+        output = model(inp).detach().numpy().reshape(-1)
+    end = time.time()
+    avg_us = (end - start) / ITERATIONS * 1e6
+    np.savetxt("py_output.txt", output)
+    return avg_us, output
+
+
+def benchmark_cpp():
+    subprocess.run(["g++", "-O3", "fc_inference.cpp", "-o", "fc_inference"], check=True)
+    result = subprocess.run(["./fc_inference", str(ITERATIONS)], capture_output=True, text=True, check=True)
+    cpp_time = float(result.stdout.strip())
+    cpp_output = np.loadtxt("cpp_output.txt").reshape(-1)
+    return cpp_time, cpp_output
+
+
+def main():
+    model, inp = save_data()
+    py_time, py_output = benchmark_python(model, inp)
+    cpp_time, cpp_output = benchmark_cpp()
+    speedup = py_time / cpp_time
+    print(f"Python avg time: {py_time:.2f} us")
+    print(f"C++ avg time: {cpp_time:.2f} us")
+    print(f"Speedup: {speedup:.2f}x")
+    if np.allclose(py_output, cpp_output, atol=1e-5):
+        print("Outputs match within tolerance")
+    else:
+        max_diff = np.max(np.abs(py_output - cpp_output))
+        print(f"Outputs differ (max diff {max_diff})")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/fc_inference.cpp
+++ b/fc_inference.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include <chrono>
+#include <algorithm>
+
+std::vector<float> read_data(const std::string &path, size_t expected) {
+    std::ifstream in(path);
+    if (!in) {
+        std::cerr << "Failed to open " << path << std::endl;
+        std::exit(1);
+    }
+    std::vector<float> data;
+    float v;
+    while (in >> v) {
+        data.push_back(v);
+    }
+    if (data.size() != expected) {
+        std::cerr << "Unexpected size for " << path << " (got " << data.size()
+                  << ", expected " << expected << ")" << std::endl;
+        std::exit(1);
+    }
+    return data;
+}
+
+int main(int argc, char **argv) {
+    const int input_dim = 10;
+    const int hidden_dim = 20;
+    const int output_dim = 1;
+    int iters = 10000;
+    if (argc > 1) iters = std::stoi(argv[1]);
+
+    auto fc1_w = read_data("fc1_weight.txt", hidden_dim * input_dim);
+    auto fc1_b = read_data("fc1_bias.txt", hidden_dim);
+    auto fc2_w = read_data("fc2_weight.txt", output_dim * hidden_dim);
+    auto fc2_b = read_data("fc2_bias.txt", output_dim);
+    auto input = read_data("input.txt", input_dim);
+
+    std::vector<float> hidden(hidden_dim);
+    std::vector<float> output(output_dim);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int iter = 0; iter < iters; ++iter) {
+        for (int i = 0; i < hidden_dim; ++i) {
+            float sum = fc1_b[i];
+            for (int j = 0; j < input_dim; ++j) {
+                sum += fc1_w[i * input_dim + j] * input[j];
+            }
+            hidden[i] = std::max(0.0f, sum);
+        }
+        for (int i = 0; i < output_dim; ++i) {
+            float sum = fc2_b[i];
+            for (int j = 0; j < hidden_dim; ++j) {
+                sum += fc2_w[i * hidden_dim + j] * hidden[j];
+            }
+            output[i] = sum;
+        }
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    double total_us = std::chrono::duration<double, std::micro>(end - start).count();
+    std::ofstream out_file("cpp_output.txt");
+    for (float v : output) out_file << v << " ";
+    std::cout << (total_us / iters) << std::endl;
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Implement C++ inference for the two-layer `SimpleFCModel` with manual linear and ReLU operations.
- Provide `benchmark.py` to export random parameters, time PyTorch and C++ inference, report speedup, and verify output parity.

## Testing
- `python benchmark.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy torch` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68975ca5bed08322b6c4b8b9b0813584